### PR TITLE
Add transfer money endpoint that use only target userId

### DIFF
--- a/server/endpoints.js
+++ b/server/endpoints.js
@@ -109,6 +109,23 @@ function setupEndpoints (server) {
     })
   })
 
+  const transferByUserIdSchema = Joi.object().keys({
+    fromAccountId: Joi.string().min(1).required(),
+    toUserId: Joi.string().min(1).required(),
+    amount: Joi.string().min(1).required(),
+    currency: Joi.string().min(3).max(3).trim().uppercase().required()
+  })
+  server.route({
+    method: 'POST',
+    path: '/api/transferByUserId',
+    handler: createHandler((request, reply) => {
+      const valid = validate(request.payload, transferByUserIdSchema)
+      const actorId = request.auth.credentials.id
+      return AccountService.transferByUserId(valid, actorId)
+      .then((transactionHistory) => reply({ transactionHistory }))
+    })
+  })
+
   server.route({
     method: 'GET',
     path: '/api/history/{accountId}',

--- a/server/services/starter.js
+++ b/server/services/starter.js
@@ -6,6 +6,7 @@ const T = require('tcomb')
 const User = require('../models/user')
 
 const AccountService = require('./account')
+const Account = require('../models/account')
 const UserService = require('./user')
 
 const getStarter = P.coroutine(function * (userId, defaultCurrency) {
@@ -22,7 +23,8 @@ const getStarter = P.coroutine(function * (userId, defaultCurrency) {
   // using the default currency.
   if (!accounts.length) {
     const account = yield AccountService.create({
-      currency: defaultCurrency
+      currency: defaultCurrency,
+      type: Account.TYPE_MAIN
     }, userId)
     accounts = [account]
   }


### PR DESCRIPTION
- 1st time that user create user's account and call starter api. It will create money account type = 11 that's a main account of the user.

- For transfer money. It will send the money directly to the main account of target user.